### PR TITLE
Fix streamlit app path

### DIFF
--- a/main.py
+++ b/main.py
@@ -90,7 +90,7 @@ def run_streamlit_app():
     """
     Lanza la interfaz gráfica de Kraken con Streamlit.
     """
-    app_path = Path(__file__).parent / "kraken" / "ui" / "streamlit_app.py"
+    app_path = Path(__file__).parent / "ui" / "streamlit_app.py"
     subprocess.run([sys.executable, "-m", "streamlit", "run", str(app_path)])
 
 def main():


### PR DESCRIPTION
## Summary
- correct path to Streamlit entry point

## Testing
- `pytest -q`
- `python main.py` *(fails: No module named 'kraken')*

------
https://chatgpt.com/codex/tasks/task_e_684c3cb3a4688330b3a40108e99326e3