### PR TITLE
Improve Streamlit UI

### DIFF
--- a/kraken/ui/assets/kraken.css
+++ b/kraken/ui/assets/kraken.css
@@ -1,1 +1,9 @@
-/* Default Kraken styles */
+/* Kraken default styles */
+html, body, .stApp {
+    background-color: var(--kraken-bg);
+    font-family: "Segoe UI", Roboto, Arial, sans-serif;
+}
+
+.stButton>button, .stTextInput>div>div>input, .stTextArea>div>textarea {
+    border-radius: 6px;
+}

--- a/kraken/ui/assets/kraken_dark.css
+++ b/kraken/ui/assets/kraken_dark.css
@@ -1,1 +1,5 @@
 /* Dark mode overrides */
+html, body, .stApp {
+    background-color: #0e1117;
+    color: #f1f1f1;
+}

--- a/kraken/ui/components/modals.py
+++ b/kraken/ui/components/modals.py
@@ -27,11 +27,11 @@ def open_modal(
         if submitted:
             if on_submit and data is not None:
                 on_submit(data)
-            st.experimental_rerun()
+            st.rerun()
         elif cancelled:
             if on_cancel:
                 on_cancel()
-            st.experimental_rerun()
+            st.rerun()
 
 def confirm_modal(
     title: str,
@@ -52,11 +52,11 @@ def confirm_modal(
         cancelled = cols[1].button(cancel_label, key=f"{key}_no")
         if confirmed:
             on_confirm()
-            st.experimental_rerun()
+            st.rerun()
         elif cancelled:
             if on_cancel:
                 on_cancel()
-            st.experimental_rerun()
+            st.rerun()
 
 def info_modal(
     title: str,
@@ -68,5 +68,5 @@ def info_modal(
     """
     with st.modal(title, key=key):
         st.write(message)
-        st.button("Cerrar", key=f"{key}_close", on_click=st.experimental_rerun)
+        st.button("Cerrar", key=f"{key}_close", on_click=st.rerun)
 

--- a/kraken/ui/components/style.py
+++ b/kraken/ui/components/style.py
@@ -29,6 +29,7 @@ def apply_theme():
     st.markdown("<meta name='viewport' content='width=device-width, initial-scale=1'>", unsafe_allow_html=True)
     # Aplica CSS principal
     load_css("kraken.css")
+    inject_variables()
     # Si dark mode está habilitado, aplica CSS adicional
     if getattr(config.ui, "enable_dark_mode", False):
         dark_on = st.session_state.get("dark_mode", False)
@@ -47,7 +48,7 @@ def theme_toggle_button():
     label = "🌙 Modo oscuro" if not dark_on else "☀️ Modo claro"
     if st.sidebar.button(label, key="theme_toggle"):
         st.session_state["dark_mode"] = not dark_on
-        st.experimental_rerun()
+        st.rerun()
 
 def kraken_logo(height: int = 48):
     """

--- a/kraken/ui/pages/duplicates.py
+++ b/kraken/ui/pages/duplicates.py
@@ -48,13 +48,26 @@ def render_duplicates():
         # Permitir editar decisión si se desea
         if st.button(f"Modificar decisión", key=f"edit_decision_{dupe.id}"):
             def on_confirm_duplicate():
-                duplicate_service.resolve_duplicate(dupe.cde_a, dupe.cde_b, True, user, comment="Modificado")
+                duplicate_service.resolve_duplicate(
+                    dupe.cde_a,
+                    dupe.cde_b,
+                    True,
+                    user,
+                    comment="Modificado",
+                )
                 show_toast("Marcado como duplicados.", type="success")
-                st.experimental_rerun()
+                st.rerun()
+
             def on_confirm_no_duplicate():
-                duplicate_service.resolve_duplicate(dupe.cde_a, dupe.cde_b, False, user, comment="Modificado")
+                duplicate_service.resolve_duplicate(
+                    dupe.cde_a,
+                    dupe.cde_b,
+                    False,
+                    user,
+                    comment="Modificado",
+                )
                 show_toast("Marcado como NO duplicados.", type="warning")
-                st.experimental_rerun()
+                st.rerun()
             open_modal(
                 title="¿Modificar la decisión de duplicidad?",
                 body_func=lambda: st.write("Selecciona nueva decisión para este par:"),

--- a/kraken/ui/pages/feedback.py
+++ b/kraken/ui/pages/feedback.py
@@ -75,7 +75,7 @@ def render_feedback():
         if form_data:
             fb = feedback_service.register_feedback(**form_data)
             show_toast("¡Feedback registrado correctamente!", type="success")
-            st.experimental_rerun()
+            st.rerun()
     else:
         st.info("Selecciona un atributo físico y escribe tu usuario para enviar feedback.")
 


### PR DESCRIPTION
## Summary
- refactor Streamlit pages and components to use `st.rerun`
- inject variables and better defaults when applying theme
- add basic UI styles and dark theme overrides

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca58fd62883309392ddd81a3c2949